### PR TITLE
Fixed typo in src/App.svelte

### DIFF
--- a/wordle/src/App.svelte
+++ b/wordle/src/App.svelte
@@ -3,7 +3,7 @@
     import KeyBoard from "./components/KeyBoard.svelte";
 </script>
 <main>
-	<nav>Worde Clone</nav>
+	<nav>Wordle Clone</nav>
 
     <Board/>
     <KeyBoard/>


### PR DESCRIPTION
Changed form "Worde" to "Wordle"